### PR TITLE
Fix date-time regex for format validator

### DIFF
--- a/VVJSONSchemaValidation/VVJSONSchemaFormatValidator.m
+++ b/VVJSONSchemaValidation/VVJSONSchemaFormatValidator.m
@@ -211,7 +211,7 @@ static NSMutableDictionary *blockBasedFormats;
 
 + (NSRegularExpression *)dateTimeRegularExpression
 {
-    NSString *pattern = @"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:.\\d+)?Z$";
+    NSString *pattern = @"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:.\\d+)?((\\-|\\+)\\d{2}:\\d{2}|Z)$";
     
     NSRegularExpression *regexp = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:NULL];
     NSAssert(regexp != nil, @"Format regular expression must be valid.");


### PR DESCRIPTION
Previously the date-time regex required fields with a date-time format to end with the 'Z' offset indicating 0 offset from utc. No other offset formats would validate against the regex. However, JSON schema uses the [rfc3339#section-5.6](http://tools.ietf.org/html/rfc3339#section-5.6) standard which allows both the 'Z' and a time-numoffset format (e.g, -08:00, +02:00) for the utc offset. This was causing the validator to fail on date-time values that it should have succeeded. This change allows the library to correctly validate either the 'Z' format or the time-numoffset for utc offsets in date-time format properties.
